### PR TITLE
Convert zfit-feedstock to v1 feedstock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output
+# Pixi's configuration
+.pixi

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,21 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak "s/platforms = .*/platforms = [\"linux-${arch}\"]/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -57,20 +67,16 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build currently doesn't support debug mode"
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    rattler-build build --recipe "${RECIPE_ROOT}" \
+     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+     ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
+     --extra-meta flow_run_id="${flow_run_id:-}" \
+     --extra-meta remote_url="${remote_url:-}" \
+     --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,3 +7,5 @@ github:
   tooling_branch_name: main
 conda_build:
   pkg_format: '2'
+conda_install_tool: pixi
+conda_build_tool: rattler-build

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,34 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: toml -*-
+
+[project]
+name = "zfit-feedstock"
+version = "3.47.0"
+description = "Pixi configuration for conda-forge/zfit-feedstock"
+authors = ["@conda-forge/zfit"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "win-64"]
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks]
+inspect-all = "inspect_artifacts --all-packages"
+build = "rattler-build build --recipe recipe"
+"build-linux_64_" = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
+"inspect-linux_64_" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+
+[feature.smithy.tasks]
+build-locally = "python ./build-locally.py"
+smithy = "conda-smithy"
+rerender = "conda-smithy rerender"
+lint = "conda-smithy lint recipe"
+
+[environments]
+smithy = ["smithy"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -29,6 +29,7 @@ requirements:
     - python >=${{ python_min }},<3.13
     - tensorflow-base >=2.16.0,<2.19.0
     - tensorflow-probability >=0.24.0,<0.26.0
+    - tf-keras
     - scipy >=1.3
     - boost-histogram
     - colorlog

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: zfit
-  version: 0.24.3
+  version: 0.25.0
   python_min: 3.9
 
 package:
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
-  sha256: 0efe47a5c597f7c730ac25495625f8bb4460f2fa4a0f4c387f503339ac8e91b5
+  sha256: ac5a92bc284094eae55dd9afe1fe2c8f3f67a402dfc7a8ad6087a9ea29ff2b41
 
 build:
   number: 1
@@ -26,20 +26,22 @@ requirements:
     - setuptools_scm
     - setuptools_scm_git_archive
   run:
-    - python >=${{ python_min }},<3.13
-    - tensorflow-base >=2.16.0,<2.19.0
-    - tensorflow-probability >=0.24.0,<0.26.0
+    - python-xxhash
+    - tensorflow >=2.16.2,<2.20
+    - python >={{ python_min }},<3.13
+    - tensorflow-base >=2.16.0,<2.20.0
+    - tensorflow-probability >=0.24,<0.27
     - tf-keras
-    - scipy >=1.3
+    - scipy >=1.2
     - boost-histogram
     - colorlog
     - deprecated
     - dill
     - dotmap
-    - uproot
+    - uproot >=4
     - pandas
-    - numpy
-    - iminuit >=2.4
+    - numpy >=1.16
+    - iminuit >=2.3
     - frozendict
     - hist
     - texttable

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,29 +1,32 @@
-{% set name = "zfit" %}
-{% set version = "0.24.3" %}
-{% set python_min = "3.9" %}
+schema_version: 1
+
+context:
+  name: zfit
+  version: 0.24.3
+  python_min: 3.9
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: ${{ name|lower }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
   sha256: 0efe47a5c597f7c730ac25495625f8bb4460f2fa4a0f4c387f503339ac8e91b5
 
 build:
-  number: 0
-  script: '{{ PYTHON }} -m pip install . -vv '
+  number: 1
   noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python {{ python_min }}
+    - python 3.9.*
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
   run:
-    - python >={{ python_min }},<3.13
+    - python >=${{ python_min }},<3.13
     - tensorflow-base >=2.16.0,<2.19.0
     - tensorflow-probability >=0.24.0,<0.26.0
     - scipy >=1.3
@@ -54,26 +57,24 @@ requirements:
     - attrs
     - zfit_interface
 
-
-test:
-  requires:
-    - python {{ python_min }}
-  imports:
-    - zfit
-    - zfit.core
-    - zfit.minimizers
-    - zfit.models
-    - zfit.util
-    - zfit.z
-
+tests:
+  - python:
+      imports:
+        - zfit
+        - zfit.core
+        - zfit.minimizers
+        - zfit.models
+        - zfit.util
+        - zfit.z
+      pip_check: false
+      python_version: ${{ python_min }}.*
 about:
-  home: https://github.com/zfit/zfit
   license: BSD-3-Clause
-  license_family: BSD
   license_file: LICENSE
   summary: scalable pythonic model fitting for High Energy Physics
-  doc_url: https://zfit.readthedocs.io/
-  dev_url: https://github.com/zfit/zfit
+  homepage: https://github.com/zfit/zfit
+  repository: https://github.com/zfit/zfit
+  documentation: https://zfit.readthedocs.io/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
This PR converts zfit-feedstock to a v1 recipe and switch the conda build tool to rattler-build.
It has been automatically generated with [feedrattler v0.3.12](https://github.com/hadim/feedrattler).

Changes:
- [x] 📝 Converted `meta.yaml` to `recipe.yaml`
- [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
- [x] 🔧 Updated `conda-forge.yml` to use `rattler-build` and `pixi` (optional)
- [x] 🔢 Bumped the build number
- [x] 🐍 Applied temporary fixes for `python_min` and `python_version`
- [x] 🔄 Rerender the feedstock with conda-smithy
- [ ] Ensured the license file is being packaged.
